### PR TITLE
fix: add ñ character

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -80,7 +80,7 @@ class Utils {
    * @static
    */
   static getRandomString(length) {
-    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    const chars = 'ABCDEFGHIJKLMNÑOPQRSTUVWXYZabcdefghijklmnñopqrstuvwxyz0123456789';
     return (new Array(length))
     .fill('')
     .reduce((acc) => acc + chars.charAt(Math.floor(Math.random() * chars.length)), '');


### PR DESCRIPTION
### What does this PR do?
Just add an ñ/Ñ character to getRandomString function
Because there are people who wants spanish random strings xD

### How should it be tested manually?

```bash
yarn test
# or
npm test
```
